### PR TITLE
Fix crash when no issues in github project

### DIFF
--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -81,7 +81,11 @@ def pullGithubAPIData():
 		if token != "":
 			params = "?access_token=" + token
 		# load the github API. github_repo looks like "jaxbot/github-issues.vim", for ex.
-		github_datacache[current_repo] = urllib2.urlopen("https://api.github.com/repos/" + urllib2.quote(current_repo) + "/issues" + params).read()
+		try:
+			github_datacache[current_repo] = urllib2.urlopen("https://api.github.com/repos/" + urllib2.quote(current_repo) + "/issues" + params).read()
+		except urllib2.HTTPError as e:
+			if e.code == 410:
+				github_datacache[current_repo] = json.dumps([])
 		cache_count = 0
 	else:
 		cache_count += 1


### PR DESCRIPTION
Fixes #22 urllib2.HTTPError: HTTP Error 410: Gone when no issues in
github project as well.

```
Error detected while processing function <SNR>14_setupOmni:
line    8:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 59, in pullGithubAPIData
  File "/usr/lib64/python2.7/urllib2.py", line 127, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 410, in open
    response = meth(req, response)
  File "/usr/lib64/python2.7/urllib2.py", line 523, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python2.7/urllib2.py", line 448, in error
    return self._call_chain(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 382, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 531, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
urllib2.HTTPError: HTTP Error 410: Gone
```

Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
