### PR TITLE
Encode issue string as UTF-8

### DIFF
--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -99,7 +99,7 @@ def dumpIssuesIntoBuffer():
 	# its an array, so dump these into the current (issues) buffer
 	for issue in current_issues:
 		issuestr = str(issue["number"]) + " " + issue["title"]
-		vim.current.buffer.append(issuestr)
+		vim.current.buffer.append(issuestr.encode('utf-8'))
 
 	# append leaves an unwanted beginning line. delete it.
 	vim.command("1delete _")


### PR DESCRIPTION
Was getting a `TypeError: bad argument type for built-in operation` when running `:Gissues`.

After some tracing I found it was cause `isssuestr` was encoded as default python unicode (UCS-2) and my vim wanted UTF-8. Thus, I think we need to re-encode the string as such.

(I'm on linux w/ vim+tmux)
