### PR TITLE
Allow file paths with special characters

### DIFF
--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -43,7 +43,7 @@ def getRepoURI():
 	global current_repo, github_repos
 
 	# get the directory the current file is in
-	filepath = vim.eval("expand('%:p:h')")
+	filepath = vim.eval("shellescape(expand('%:p:h'))")
 
 	# cache the github repo for performance
 	if github_repos.get(filepath,'') != '':


### PR DESCRIPTION
Really simple fix. You could also use python's `pipes.quote` function, but I thought it might be better to just use vim.
