### PR TITLE
Allow URLs where user doesn't exist.

### DIFF
--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -272,7 +272,7 @@ if !exists("g:github_upstream_issues")
 endif
 
 if !exists("g:github_issues_urls")
-	let g:github_issues_urls = ["git@github.com:", "https://github.com/"]
+	let g:github_issues_urls = ["git@github.com:", "https://github.com/", "github.com:"]
 endif
 
 if !exists("g:github_api_url")


### PR DESCRIPTION
This is commonly a case where github isn't detected, because a user may have something similar to the following in their SSH configuration:

```
Host github.com
User git
```
