### PR TITLE
Allows 'g:github_access_token' to be a filepath.

### DIFF
--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -130,6 +130,11 @@ endif
 
 if !exists("g:github_access_token")
 	let g:github_access_token = ""
+elseif filereadable(simplify("g:github_access_token"))
+  let lines = readfile(g:github_access_token)
+  if !empty(lines)
+    let g:github_access_token=lines[0]
+  endif
 endif
 
 if !exists("g:github_upstream_issues")


### PR DESCRIPTION
A very small patch; it allows one to use the `g:github_access_token` variable as a filepath to read a token to be used. This way, one doesn't have to write such a secure token within their `.vimrc`.
