### PR TITLE
Fix bug when assignees are set

### DIFF
--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -185,9 +185,10 @@ def showIssue():
 		b.append("## Reported By: " + issue["user"]["login"].encode(vim.eval("&encoding")))
 
 	b.append("## State: " + issue["state"])
-
-	if issue["assignee"]:
+	if issue['assignee']:
 		b.append("## Assignee: " + issue["assignee"]["login"].encode(vim.eval("&encoding")))
+	elif number == "new":
+		b.append("## Assignee: ")
 
 	labelstr = ""
 	if issue["labels"]:


### PR DESCRIPTION
This is a temporary pull. (Big refactor coming when I get more time) ... but there was an issue where the current v3 assignee hash has changed. We want to show "login" value from this hash.
