### PR TITLE
Fix "gissues hasn't closes correctly" #66

### DIFF
--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -76,6 +76,7 @@ def showIssueList(labels, ignore_cache = False):
 
   if repourl == "":
     print "Failed to find a suitable Github repository URL, sorry!"
+    vim.command("let github_failed = " + str("1"))
     return
 
   if not vim.eval("g:github_same_window") == "1":

--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -24,12 +24,17 @@ endif
 function! s:showGithubIssues(...) 
   call ghissues#init()
 
+  let github_failed = 0
   if a:0 < 1
     python showIssueList(0, "True")
   else
     python showIssueList(vim.eval("a:1"), "True")
   endif
-  
+
+  if github_failed == "1"
+    return
+  endif
+
   " its not a real file
   set buftype=nofile
 


### PR DESCRIPTION
```
Failed to find a suitable Github repository URL, sorry!

Error detected while processing function <SNR>16_showIssue:
line    3:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 150, in showIssueBuffer
vim.error: Vim(python):Traceback (most recent call last):

E382: Cannot write, 'buftype' option is not set
```

This caused because after not found GH repo script doesn't stop.

Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
