### PR TITLE
Added support for non-HTTPs repositories

### DIFF
--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -150,7 +150,7 @@ if !exists("g:github_upstream_issues")
 endif
 
 if !exists("g:github_issues_urls")
-  let g:github_issues_urls = ["github.com:", "https://github.com/"]
+  let g:github_issues_urls = ["github.com:", "github.com/"]
 endif
 
 if !exists("g:github_api_url")


### PR DESCRIPTION
The hard-coded "https://" made it impossible to use repositories cloned through SSH.
