### PR TITLE
Avoid errors that occur when milestones were non ascii characters.

### DIFF
--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -286,7 +286,7 @@ def populateOmniComplete():
   milestones = getMilestoneList(url)
   if milestones is not None:
     for milestone in milestones:
-      addToOmni(str(milestone["title"]), 'Milestone')
+      addToOmni(str(milestone["title"]).encode('utf-8'), 'Milestone')
 
 # adds <keyword> to omni dictionary. used by populateOmniComplete
 def addToOmni(keyword, typ):


### PR DESCRIPTION
When I write a commit message, the following error has occurred.

```
Error detected while processing function <SNR>106_setupOmni:
line    9:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 282, in populateOmniComplete
UnicodeEncodeError: 'ascii' codec can't encode characters in position 2-13: ordinal not in range(128)
```
