### PR TITLE
set codeblock regex from vim original pattern

### DIFF
--- a/syntax/gfimarkdown.vim
+++ b/syntax/gfimarkdown.vim
@@ -72,7 +72,7 @@ syn region markdownBoldItalic start="\<\*\*\*\|\*\*\*\>" end="\<\*\*\*\|\*\*\*\>
 syn region markdownBoldItalic start="\<___\|___\>" end="\<___\|___\>" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
-syn region markdownGHCodeBlock matchgroup=markdownCodeDelimiter start="^\s*$\n\s*```\s\?\S*\s*$" end="\s*```$\n\s*\n" contained  keepend
+syn region markdownGHCodeBlock matchgroup=markdownCodeDelimiter start="^\s*```.*$" end="^\s*```\ze\s*$" keepend
 
 syn match markdownEscape "\\[][\\`*_{}()#+.!-]"
 


### PR DESCRIPTION
The present syntax cannot color code blocks that are not caught by empty lines. The [Github Flavored Markdown Document][gfmd] says that blocks may be allowed.

> fenced code blocks don't have to be preceded by a blank line

[gfmd]: https://help.github.com/articles/github-flavored-markdown/

```markdown
some code
.```
code to be colored
.```
some code
```

This patch can color them by using the regex from [Vim original code][code].

[code]: https://github.com/b4winckler/vim/blob/master/runtime/syntax/markdown.vim#L86