### PR TITLE
adding the map to open an issue in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ They're also totally editable buffers, and saving the file will sync with Github
 
 <img src='https://jaxbot.me/pics/vim/vim-github-issues-4.gif'>
 
+You can also open the current issue in your browser using `cb`.
+
 ### Creating issues
 
 You can even use `:Giadd` to create a blank issue. Saving the buffer will generate a new issue and update the buffer with an issue number and the ability to add comments.

--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -449,6 +449,9 @@ def showIssueBuffer(number, url = ""):
     vim.command("silent new +set\ buftype=nofile")
   vim.command("edit gissues/" + repourl + "/" + number)
 
+def browse():
+  vim.command("call netrw#NetrwBrowseX(b:ghissue_url,0)")
+
 # show an issue buffer in detail
 def showIssue(number=False, repourl=False):
   if repourl is False:
@@ -474,10 +477,11 @@ def showIssue(number=False, repourl=False):
       'labels': []
     }
   else:
-    vim.command("let b:ghissue_number="+number)
-    vim.command("let b:ghissue_repourl=\""+repourl+"\"")
     url = ghUrl("/issues/" + number, repourl)
     issue = json.loads(urllib2.urlopen(url).read())
+    vim.command("let b:ghissue_url=\""+issue["html_url"]+"\"")
+    vim.command("let b:ghissue_number="+number)
+    vim.command("let b:ghissue_repourl=\""+repourl+"\"")
 
   b.append("## Title: " + issue["title"].encode(vim.eval("&encoding")) + " (" + str(issue["number"]) + ")")
   if issue["user"]["login"]:

--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -96,6 +96,10 @@ function! s:setIssueState(state)
   python setIssueData({ 'state': 'open' if vim.eval("a:state") == '1' else 'closed' })
 endfunction
 
+function! s:browse()
+  python browse()
+endfunction
+
 function! s:updateIssue()
   call ghissues#init()
   python showIssue()
@@ -236,6 +240,7 @@ command! -nargs=* Gishow call s:showThisIssue(<f-args>)
 autocmd BufReadCmd gissues/*/\([0-9]*\|new\) call s:updateIssue()
 autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> cc :call <SID>setIssueState(0)<cr>
 autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> co :call <SID>setIssueState(1)<cr>
+autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> cb :call <SID>browse()<cr>
 autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> <cr> :call <SID>handleEnter()<cr>
 autocmd BufWriteCmd gissues/*/[0-9a-z]* call s:saveIssue()
 


### PR DESCRIPTION
Hey! Now that the bigger changes were merged in, I can add things in small chunks.  So here comes a mapping to open an issue in your browser.

I mapped 'cb' to open an issue in the browser.  I think this is useful
while new users are getting used to how to use this plugin.

I am totally open to suggestions on what to map this to, but I figured 'cb' seemed like a reasonable start.

To test:
1. open an issue or a pr
2. press 'cb'
3. At this point I expect that the current issue or pr will be opened in your browser