### PR TITLE
netrw#NetrwBrowseX was renamed in newer version of vim

### DIFF
--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -449,9 +449,6 @@ def showIssueBuffer(number, url = ""):
     vim.command("silent new +set\ buftype=nofile")
   vim.command("edit gissues/" + repourl + "/" + number)
 
-def browse():
-  vim.command("call netrw#NetrwBrowseX(b:ghissue_url,0)")
-
 # show an issue buffer in detail
 def showIssue(number=False, repourl=False):
   if repourl is False:

--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -97,7 +97,11 @@ function! s:setIssueState(state)
 endfunction
 
 function! s:browse()
-  python browse()
+  if has("patch-7.4.567")
+    call netrw#BrowseX(b:ghissue_url,0)
+  else
+    call netrw#NetrwBrowseX(b:ghissue_url,0)
+  endif
 endfunction
 
 function! s:updateIssue()


### PR DESCRIPTION
This change makes our use or the browse function backwards compatible.

More information about the change in vim, and the fix here: https://github.com/tpope/vim-fugitive/issues/594