### PR TITLE
Allow `Gishow` to take a single param and fall back to current working directories remote repo

### DIFF
--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -62,6 +62,8 @@ def getRepoURI():
   except subprocess.CalledProcessError:
     github_repos[filepath] = ""
     return github_repos[filepath]
+  except OSError:
+    all_remotes = subprocess.check_output( ['git', 'remote', '-v'])
 
   # Try to get the remote for the current branch/HEAD.
   try:

--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -97,8 +97,6 @@ function! s:showThisIssue(...)
 
   silent tabe
   set buftype=nofile
-  let name = "gissues/" . a:2 . "/" . a:1
-  execute 'edit' name
   normal ggdG
 
   " map the enter key to show issue or click link
@@ -106,7 +104,15 @@ function! s:showThisIssue(...)
   nnoremap <buffer> s :call <SID>showIssueLink("","","True")<cr>
   nnoremap <buffer> <silent> q :q<CR>
 
-  python showIssue(vim.eval("a:1"),vim.eval("a:2"))
+  if a:0 > 1
+    let name = "gissues/" . a:2 . "/" . a:1
+    execute 'edit' name
+    python showIssue(vim.eval("a:1"),vim.eval("a:2"))
+  else
+    let name = "gissues/" . a:1
+    execute 'edit' name
+    python showIssue(vim.eval("a:1"))
+  endif
 endfunction
 
 function! s:setIssueState(state)

--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -92,6 +92,23 @@ function! s:showIssue(...)
   setlocal nomodified
 endfunction
 
+function! s:showThisIssue(...)
+  call ghissues#init()
+
+  silent tabe
+  set buftype=nofile
+  let name = "gissues/" . a:2 . "/" . a:1
+  execute 'edit' name
+  normal ggdG
+
+  " map the enter key to show issue or click link
+  nnoremap <buffer> <cr> :call <SID>showIssueLink("","","False")<cr>
+  nnoremap <buffer> s :call <SID>showIssueLink("","","True")<cr>
+  nnoremap <buffer> <silent> q :q<CR>
+
+  python showIssue(vim.eval("a:1"),vim.eval("a:2"))
+endfunction
+
 function! s:setIssueState(state)
   python setIssueData({ 'state': 'open' if vim.eval("a:state") == '1' else 'closed' })
 endfunction
@@ -207,23 +224,6 @@ function! s:setMilestone(title)
 
   let g:github_current_milestone = title
 
-endfunction
-
-function! s:showThisIssue(...)
-  call ghissues#init()
-
-  silent tabe
-  set buftype=nofile
-  let name = "gissues/" . a:2 . "/" . a:1
-  execute 'edit' name
-  normal ggdG
-
-  " map the enter key to show issue or click link
-  nnoremap <buffer> <cr> :call <SID>showIssueLink("","","False")<cr>
-  nnoremap <buffer> s :call <SID>showIssueLink("","","True")<cr>
-  nnoremap <buffer> <silent> q :q<CR>
-
-  python showIssue(vim.eval("a:1"),vim.eval("a:2"))
 endfunction
 
 function! s:commitHighlighting()

--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -105,11 +105,11 @@ function! s:showThisIssue(...)
   nnoremap <buffer> <silent> q :q<CR>
 
   if a:0 > 1
-    let name = "gissues/" . a:2 . "/" . a:1
+    let name = "gissue/" . a:2 . "/" . a:1
     execute 'edit' name
     python showIssue(vim.eval("a:1"),vim.eval("a:2"))
   else
-    let name = "gissues/" . a:1
+    let name = "gissue/" . a:1
     execute 'edit' name
     python showIssue(vim.eval("a:1"))
   endif


### PR DESCRIPTION
This change gives `:Gishow` the ability to accept 1 or 2 params.

examples:
`:Gishow 143`  will fallback to the current working directories remote repo
`:Gishow 143 jaxbot/github-issues.vim`  will open issue 143 of jaxbot/github-issues.vim

