### PR TITLE
Fix loading the same page multiple times

### DIFF
--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -317,9 +317,9 @@ def getGHList(ignore_cache, repourl, endpoint, params):
       more_to_load = True
 
       page = 1
-      params['page'] = str(page)
 
       while more_to_load and page <= int(vim.eval("g:github_issues_max_pages")):
+        params['page'] = str(page)
 
         # TODO This should be in ghUrl() I think
         qs = string.join([ k+'='+v for ( k, v ) in params.items()], '&')


### PR DESCRIPTION
Once the page value was incremented it wasn't actually updated in the query, so it just showed the same 30 issues repeatedly.