### PR TITLE
fix branch name being saved in a PR body

### DIFF
--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -640,7 +640,7 @@ def saveGissue():
       issue['assignee'] = assignee[1].strip()
       continue
 
-    if line == SHOW_COMMITS or line == SHOW_FILES_CHANGED:
+    if line == SHOW_COMMITS or line == SHOW_FILES_CHANGED or "## Branch Name:" in line:
       continue
 
     if issue['body'] != '':


### PR DESCRIPTION
When I added branch name to the display for PRs, I did not add a change
to ignore the branch name when saving a issue, so if I tried to update
an issue, it would include the branch name in the issue body.