### PR TITLE
Add issue searches using the github search api

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ How awesome is that!?
 
 New feature: Use `:Gmiles` to open a menu of milestones. Press return on one to select it and filter `:Gissues` by that milestone from then on.
 
+### Custom Issue Search
+
+You have the ability to define your own issue search using [Githubs search API](https://developer.github.com/v3/search/). This allows you to view issues and pull requests across repos.
+
+To use this feature, you can add a line like the following, with the search parameters that you wish to use.
+
+```vim
+let g:gh_issues_query = "state:open user:github label:\"feature\" sort:created-asc"
+```
+
+You can than get this list of issues using the command `:Gisearch`
+
 ### Fugitive integration
 
 Github will show any commits that reference the issue. That's what the omnicomplete helps with. But to make things even more awesome, github-issues.vim integrates with Fugitive.vim to make commit hashes clickable with the return key.

--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -226,6 +226,9 @@ def printIssueList(issues, repourl='search', labels=False, only_me=False):
   if not vim.eval("g:github_same_window") == "1":
     vim.command("silent new")
 
+  if 'labels' not in locals():
+    labels = ""
+
   # Some Vim versions don't allow noswapfile as a verb
   try:
     vim.command("noswapfile edit " + "gissues/" + repourl + "/issues")
@@ -237,16 +240,15 @@ def printIssueList(issues, repourl='search', labels=False, only_me=False):
   current_buffer = vim.current.buffer
 
   cur_milestone = str(vim.eval("g:github_current_milestone"))
-
   # its an array, so dump these into the current (issues) buffer
   for issue in issues:
     if cur_milestone != "" and (not issue["milestone"] or issue["milestone"]["title"] != cur_milestone):
       continue
 
     issuestr = str(issue["number"]) + " " + issue["title"]
-
-    for label in issue["labels"]:
-      issuestr += " [" + label["name"] + "]"
+    if 'labels' in issue:
+      for label in issue["labels"]:
+        issuestr += " [" + label["name"] + "]"
 
     current_buffer.append(issuestr.encode(vim.eval("&encoding")))
 

--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -158,8 +158,8 @@ def showCommits(split=False):
   for commit in commits:
     current_buffer.append((commit['sha'] + " " + commit['commit']['message']).split("\n"))
   vim.command("normal ggdd")
-  vim.command("nnoremap <buffer> <CR> :call <SID>handleEnter('False')<cr>")
-  vim.command("nnoremap <buffer> s :call <SID>handleEnter('True')<cr>")
+  vim.command("nnoremap <buffer> <CR> :call <SID>showIssueLink('','','False')<cr>")
+  vim.command("nnoremap <buffer> s :call <SID>showIssueLink('','','True')<cr>")
   vim.command("call <SID>commitHighlighting()")
   vim.command("let b:ghissue_repourl=\""+repourl+"\"")
   vim.command("setlocal nomodifiable")
@@ -171,7 +171,7 @@ def showCommit(sha, split=False):
   req = urllib2.Request(url, None, headers)
   diff = urllib2.urlopen(req, timeout=2)
   buffer_name = "commit/" + repourl + "/" + sha
-  newSplit(buffer_name) if split == 'True' else newTab(buffer_name)
+  newSplit(buffer_name) if split else newTab(buffer_name)
   vim.command("set syn=diff")
   vim.command("setlocal modifiable")
   current_buffer = vim.current.buffer
@@ -527,13 +527,15 @@ def showIssueLink(number, url="", split="False"):
 
   # convert string to boolean
   split = split == "True"
+  word = vim.eval("expand('<cword>')")
 
   line = vim.eval("getline(\".\")")
   if line == SHOW_COMMITS:
     showCommits(split)
-    return
-  if line == SHOW_FILES_CHANGED:
+  elif line == SHOW_FILES_CHANGED:
     showFilesChanged(split)
+  elif len(word) == 40:
+    showCommit(word, split)
 
   return
 

--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -215,6 +215,14 @@ def showIssueList(labels, ignore_cache=False, only_me=False):
     vim.command("let github_failed = 1")
     return
 
+  issues = getIssueList(repourl, '/issues', labels, ignore_cache, only_me)
+
+  printIssueList(issues, repourl, labels, only_me)
+
+def printIssueList(issues, repourl='search', labels=False, only_me=False):
+  global globissues
+  globissues = issues
+
   if not vim.eval("g:github_same_window") == "1":
     vim.command("silent new")
 
@@ -227,7 +235,6 @@ def showIssueList(labels, ignore_cache=False, only_me=False):
   vim.command("normal ggdG")
 
   current_buffer = vim.current.buffer
-  issues = getIssueList(repourl, labels, ignore_cache, only_me)
 
   cur_milestone = str(vim.eval("g:github_current_milestone"))
 
@@ -284,7 +291,7 @@ def showMilestoneList(labels, ignore_cache=False):
   vim.command("1delete _")
 
 # pulls the issue array from the server
-def getIssueList(repourl, query, ignore_cache=False, only_me=False):
+def getIssueList(repourl, endpoint, query, ignore_cache = False, only_me = False):
   global github_datacache
 
   # non-string args correspond to vanilla issues request
@@ -297,7 +304,7 @@ def getIssueList(repourl, query, ignore_cache=False, only_me=False):
   if only_me:
     params["assignee"] = getCurrentUser()
 
-  return getGHList(ignore_cache, repourl, "/issues", params)
+  return getGHList(ignore_cache, repourl, endpoint, params)
 
 def getCurrentUser():
   return ghApi("", "user", True, False)["login"]
@@ -443,7 +450,7 @@ def doPopulateOmniComplete():
   if url == "":
     return
 
-  issues = getIssueList(url, 0)
+  issues = getIssueList(url, "/issues", 0)
   for issue in issues:
     addToOmni(str(issue["number"]) + " " + issue["title"], 'Issue')
 
@@ -475,7 +482,7 @@ class AsyncOmni(threading.Thread):
     if url == "":
       return
 
-    issues = getIssueList(url, 0)
+    issues = getIssueList(url, '/issues', 0)
     labels = getLabels()
     contributors = getContributors()
     milestones = getMilestoneList(url)

--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -754,7 +754,8 @@ def saveGissue():
 
     data = ""
     try:
-      url = ghUrl("/issues")
+      repourl = getUpstreamRepoURI()
+      url = ghUrl("/issues",repourl)
       request = urllib2.Request(url, json.dumps(issue))
       data = json.loads(urllib2.urlopen(request, timeout=2).read())
       parens[2] = str(data['number'])
@@ -769,7 +770,7 @@ def saveGissue():
         print(url)
         print(issue)
   else:
-    url = ghUrl("/issues/" + number)
+    url = ghUrl("/issues/" + number, repourl)
     request = urllib2.Request(url, json.dumps(issue))
     request.get_method = lambda: 'PATCH'
     try:
@@ -780,7 +781,7 @@ def saveGissue():
 
   if commentmode == 3:
     try:
-      url = ghUrl("/issues/" + parens[2] + "/comments")
+      url = ghUrl("/issues/" + parens[2] + "/comments", repourl)
       data = json.dumps({'body': comment})
       request = urllib2.Request(url, data)
       urllib2.urlopen(request, timeout=2)
@@ -797,7 +798,8 @@ def saveGissue():
 # updates an issues data, such as opening/closing
 def setIssueData(issue):
   parens = getFilenameParens()
-  url = ghUrl("/issues/" + parens[2])
+  repourl = getUpstreamRepoURI()
+  url = ghUrl("/issues/" + parens[2], repourl)
   request = urllib2.Request(url, json.dumps(issue))
   request.get_method = lambda: 'PATCH'
   urllib2.urlopen(request, timeout = 2)

--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -801,6 +801,7 @@ def saveGissue():
         print(url)
         print(issue)
   else:
+    repourl = vim.eval("b:ghissue_repourl")
     url = ghUrl("/issues/" + number, repourl)
     request = urllib2.Request(url, json.dumps(issue))
     request.get_method = lambda: 'PATCH'

--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -13,6 +13,7 @@ import string
 import subprocess
 import threading
 import time
+import urllib
 import urllib2
 import vim
 
@@ -333,7 +334,7 @@ def getGHList(ignore_cache, repourl, endpoint, params):
         params['page'] = str(page)
 
         # TODO This should be in ghUrl() I think
-        qs = string.join([ k+'='+v for ( k, v ) in params.items()], '&')
+        qs = urllib.urlencode(params)
         url = ghUrl(endpoint+'?'+qs, repourl)
 
         response = urllib2.urlopen(url, timeout = 2)

--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -514,8 +514,8 @@ def showIssueLink(number, url="", split="False"):
 
 # handle user pressing enter on the gissue list
 # possible actions: view issue, filter by label, filter by assignee, remove filters
-def showIssueBuffer(number, url=""):
-  if url != "":
+def showIssueBuffer(number, url = False):
+  if url:
     repourl = url
   else:
     repourl = getUpstreamRepoURI()

--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -228,19 +228,6 @@ function! s:setupOmni()
   let b:did_init_omnicomplete_async = 0
 endfunction
 
-function! s:handleEnter(...)
-  if len(expand("<cword>")) == 40
-    echo expand("<cword>")
-    if a:0 > 0
-      let split = a:1
-    else
-      let split = "False"
-    endif
-    let a:sha = expand("<cword>")
-    python showCommit(vim.eval("a:sha"), vim.eval("split"))
-  endif
-endfunction
-
 function! s:setMilestone(title)
   let title = ""
   if a:title != "[None]"
@@ -274,7 +261,12 @@ autocmd BufReadCmd gissues/*/\([0-9]*\|new\) call s:updateIssue()
 autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> cc :call <SID>setIssueState(0)<cr>
 autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> co :call <SID>setIssueState(1)<cr>
 autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> cb :call <SID>browse()<cr>
-autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> <cr> :call <SID>handleEnter()<cr>
+
+" map the enter key to show issue or click link
+autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> <cr> :call <SID>showIssueLink("","","False")<cr>
+autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> s :call <SID>showIssueLink("","","True")<cr>
+autocmd BufReadCmd gissues/*/\([0-9]*\|new\) nnoremap <buffer> <silent> q :q<CR>
+
 autocmd BufWriteCmd gissues/*/[0-9a-z]* call s:saveIssue()
 
 if !exists("g:github_issues_no_omni")

--- a/plugin/githubissues.vim
+++ b/plugin/githubissues.vim
@@ -59,6 +59,18 @@ function! s:showGithubIssues(...)
 
 endfunction
 
+function! s:showSearchList()
+  call ghissues#init()
+  python showSearchList()
+
+  " its not a real file
+  set buftype=nofile
+  " map the enter key to show issue
+  nnoremap <buffer> <cr> :call <SID>showIssue(expand("<cword>"),"")<cr>
+  nnoremap <buffer> i :Giadd<cr>
+  nnoremap <buffer> q :q<cr>
+endfunction
+
 function! s:showIssueLink(...)
   call ghissues#init()
   if a:0 > 2
@@ -249,6 +261,7 @@ endfunction
 
 " define the :Gissues command
 command! -nargs=* Gissues call s:showGithubIssues(<f-args>)
+command! -nargs=* Gisearch call s:showSearchList(<f-args>)
 command! -nargs=* Giadd call s:showIssue("new", <f-args>)
 command! -nargs=* Giedit call s:showIssue(<f-args>)
 command! -nargs=0 Giupdate call s:updateIssue()


### PR DESCRIPTION
This change allows a user to define their own search criteria using the [Githubs search API](https://developer.github.com/v3/search/).

This can be used by setting this
```vim
let g:gh_issues_query = "state:open user:github label:\"feature\" sort:created-asc"
```

Then running this command `:Gisearch`