### PR TITLE
Only strip trailing whitespace

### DIFF
--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -642,7 +642,7 @@ def showIssue(number=False, repourl=False):
 
   if issue["body"]:
     lines = issue["body"].encode(vim.eval("&encoding")).split("\n")
-    b.append(map(lambda line: line.strip(), lines))
+    b.append(map(lambda line: line.rstrip(), lines))
 
   if number != "new":
     b.append("## Comments")


### PR DESCRIPTION
Uses `rstrip()` instead of `strip()` to only trim trailing white space and leave proper indentation for JSON or indented markdown lists. Closes #153