### PR TITLE
Missing space in split windows

### DIFF
--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -231,7 +231,7 @@ def printIssueList(issues, repourl='search', labels=False, only_me=False):
 
   # Setup split
   if not vim.eval("g:github_same_window") == "1":
-    cmd = 'silent'
+    cmd = 'silent '
     if not vim.eval("g:gissues_list_vsplit") == "1":
       spl = 'new +set\ buftype=nofile'
       if vim.eval("g:gissues_split_height") != "0":

--- a/autoload/ghissues.vim
+++ b/autoload/ghissues.vim
@@ -589,7 +589,7 @@ def showIssueBuffer(number, url = False):
     number = vim.eval("expand('<cword>')")
 
   if not vim.eval("g:github_same_window") == "1":
-    cmd = 'silent'
+    cmd = 'silent '
     if not vim.eval("g:gissues_issue_vsplit") == "1":
       spl = 'new +set\ buftype=nofile'
       if vim.eval("g:gissues_split_height") != "0":


### PR DESCRIPTION
The command for splits was trying to merge "silent" with "new"/"vnew" without space. That's why it tried to do the command silent new in the Issue #170.